### PR TITLE
Refine and fix exception handlings

### DIFF
--- a/src/mrb_mount.c
+++ b/src/mrb_mount.c
@@ -11,9 +11,9 @@
 #include <stdio.h>
 #include <sys/mount.h>
 
-#include "mruby.h"
-#include "mruby/data.h"
-#include "mruby/error.h"
+#include <mruby.h>
+#include <mruby/data.h>
+#include <mruby/error.h>
 #include "mrb_mount.h"
 
 #define DONE mrb_gc_arena_restore(mrb, 0);
@@ -81,34 +81,34 @@ static mrb_value mrb_mount_umount(mrb_state *mrb, mrb_value self)
 
 void mrb_mruby_mount_gem_init(mrb_state *mrb)
 {
-    struct RClass *mount;
-    mount = mrb_define_class(mrb, "Mount", mrb->object_class);
-    mrb_define_method(mrb, mount, "initialize", mrb_mount_init, MRB_ARGS_NONE());
-    mrb_define_method(mrb, mount, "__mount__",  mrb_mount_mount, MRB_ARGS_REQ(5));
-    mrb_define_method(mrb, mount, "umount",     mrb_mount_umount, MRB_ARGS_ARG(1, 1));
+  struct RClass *mount;
+  mount = mrb_define_class(mrb, "Mount", mrb->object_class);
+  mrb_define_method(mrb, mount, "initialize", mrb_mount_init, MRB_ARGS_NONE());
+  mrb_define_method(mrb, mount, "__mount__",  mrb_mount_mount, MRB_ARGS_REQ(5));
+  mrb_define_method(mrb, mount, "umount",     mrb_mount_umount, MRB_ARGS_ARG(1, 1));
 
-    // please see <linux/fs.h>
-    mrb_define_const(mrb, mount, "MS_MGC_VAL",     mrb_fixnum_value(MS_MGC_VAL));
+  // please see <linux/fs.h>
+  mrb_define_const(mrb, mount, "MS_MGC_VAL",     mrb_fixnum_value(MS_MGC_VAL));
 
-    mrb_define_const(mrb, mount, "MS_DIRSYNC",     mrb_fixnum_value(MS_DIRSYNC));
-    mrb_define_const(mrb, mount, "MS_MANDLOCK",    mrb_fixnum_value(MS_MANDLOCK));
-    mrb_define_const(mrb, mount, "MS_MOVE",        mrb_fixnum_value(MS_MOVE));
-    mrb_define_const(mrb, mount, "MS_NOATIME",     mrb_fixnum_value(MS_NOATIME));
-    mrb_define_const(mrb, mount, "MS_NODEV",       mrb_fixnum_value(MS_NODEV));
-    mrb_define_const(mrb, mount, "MS_NODIRATIME",  mrb_fixnum_value(MS_NODIRATIME));
-    mrb_define_const(mrb, mount, "MS_NOEXEC",      mrb_fixnum_value(MS_NOEXEC));
-    mrb_define_const(mrb, mount, "MS_NOSUID",      mrb_fixnum_value(MS_NOSUID));
-    mrb_define_const(mrb, mount, "MS_RDONLY",      mrb_fixnum_value(MS_RDONLY));
-    mrb_define_const(mrb, mount, "MS_REMOUNT",     mrb_fixnum_value(MS_REMOUNT));
-    mrb_define_const(mrb, mount, "MS_SYNCHRONOUS", mrb_fixnum_value(MS_SYNCHRONOUS));
-    mrb_define_const(mrb, mount, "MS_BIND",        mrb_fixnum_value(MS_BIND));
-    mrb_define_const(mrb, mount, "MS_PRIVATE",     mrb_fixnum_value(MS_PRIVATE));
+  mrb_define_const(mrb, mount, "MS_DIRSYNC",     mrb_fixnum_value(MS_DIRSYNC));
+  mrb_define_const(mrb, mount, "MS_MANDLOCK",    mrb_fixnum_value(MS_MANDLOCK));
+  mrb_define_const(mrb, mount, "MS_MOVE",        mrb_fixnum_value(MS_MOVE));
+  mrb_define_const(mrb, mount, "MS_NOATIME",     mrb_fixnum_value(MS_NOATIME));
+  mrb_define_const(mrb, mount, "MS_NODEV",       mrb_fixnum_value(MS_NODEV));
+  mrb_define_const(mrb, mount, "MS_NODIRATIME",  mrb_fixnum_value(MS_NODIRATIME));
+  mrb_define_const(mrb, mount, "MS_NOEXEC",      mrb_fixnum_value(MS_NOEXEC));
+  mrb_define_const(mrb, mount, "MS_NOSUID",      mrb_fixnum_value(MS_NOSUID));
+  mrb_define_const(mrb, mount, "MS_RDONLY",      mrb_fixnum_value(MS_RDONLY));
+  mrb_define_const(mrb, mount, "MS_REMOUNT",     mrb_fixnum_value(MS_REMOUNT));
+  mrb_define_const(mrb, mount, "MS_SYNCHRONOUS", mrb_fixnum_value(MS_SYNCHRONOUS));
+  mrb_define_const(mrb, mount, "MS_BIND",        mrb_fixnum_value(MS_BIND));
+  mrb_define_const(mrb, mount, "MS_PRIVATE",     mrb_fixnum_value(MS_PRIVATE));
 
-    mrb_define_const(mrb, mount, "MNT_FORCE",  mrb_fixnum_value(MNT_FORCE));
-    mrb_define_const(mrb, mount, "MNT_DETACH", mrb_fixnum_value(MNT_DETACH));
-    mrb_define_const(mrb, mount, "MNT_EXPIRE", mrb_fixnum_value(MNT_EXPIRE));
+  mrb_define_const(mrb, mount, "MNT_FORCE",  mrb_fixnum_value(MNT_FORCE));
+  mrb_define_const(mrb, mount, "MNT_DETACH", mrb_fixnum_value(MNT_DETACH));
+  mrb_define_const(mrb, mount, "MNT_EXPIRE", mrb_fixnum_value(MNT_EXPIRE));
 
-    DONE;
+  DONE;
 }
 
 void mrb_mruby_mount_gem_final(mrb_state *mrb)

--- a/src/mrb_mount.c
+++ b/src/mrb_mount.c
@@ -53,8 +53,12 @@ static mrb_value mrb_mount_mount(mrb_state *mrb, mrb_value self)
 
   ret = mount(source, target, fstype, mountflag, data);
   if(ret == -1) {
-    perror("mount");
-    asprintf(&err_msg, "syscall mount failed. args: %s, %s, %s, %i, %s", source, target, fstype, mountflag, data);
+    char buf[1024];
+    if (strerror_r(errno, buf, 1024) == NULL) {
+      mrb_sys_fail(mrb, "[BUG] strerror_r failed at mrb_mount.c:" __LINE__ ". Please report haconiwa-dev");
+    }
+
+    asprintf(&err_msg, "syscall mount failed. message: %s, args: %s, %s, %s, %i, %s", buf, source, target, fstype, mountflag, data);
     mrb_sys_fail(mrb, err_msg);
   }
 
@@ -64,6 +68,7 @@ static mrb_value mrb_mount_mount(mrb_state *mrb, mrb_value self)
 static mrb_value mrb_mount_umount(mrb_state *mrb, mrb_value self)
 {
   char* target;
+  char* err_msg;
   mrb_value f = mrb_nil_value();
   int umountflag, ret;
 
@@ -72,8 +77,13 @@ static mrb_value mrb_mount_umount(mrb_state *mrb, mrb_value self)
 
   ret = umount2(target, umountflag);
   if(ret == -1) {
-    perror("umount");
-    mrb_sys_fail(mrb, "umount failed.");
+    char buf[1024];
+    if (strerror_r(errno, buf, 1024) == NULL) {
+      mrb_sys_fail(mrb, "[BUG] strerror_r failed at mrb_mount.c:" __LINE__ ". Please report haconiwa-dev");
+    }
+
+    asprintf(&err_msg, "umount failed: %s", buf);
+    mrb_sys_fail(mrb, err_msg);
   }
 
   return mrb_fixnum_value(ret);

--- a/src/mrb_mount.c
+++ b/src/mrb_mount.c
@@ -40,11 +40,12 @@ static mrb_value mrb_mount_mount(mrb_state *mrb, mrb_value self)
   ret = mount(source, target, fstype, mountflag, data);
   if(ret == -1) {
     char buf[1024];
-    if (strerror_r(errno, buf, 1024) == NULL) {
+    char *ret;
+    if ((ret = strerror_r(errno, buf, 1024)) == NULL) {
       mrb_sys_fail(mrb, "[BUG] strerror_r failed at mrb_mount.c:44. Please report haconiwa-dev");
     }
 
-    asprintf(&err_msg, "syscall mount failed. message: %s, args: %s, %s, %s, %i, %s", buf, source, target, fstype, mountflag, data);
+    asprintf(&err_msg, "syscall mount failed. message: %s, args: %s, %s", ret, source, target);
     mrb_sys_fail(mrb, err_msg);
   }
 
@@ -53,8 +54,8 @@ static mrb_value mrb_mount_mount(mrb_state *mrb, mrb_value self)
 
 static mrb_value mrb_mount_umount(mrb_state *mrb, mrb_value self)
 {
-  char* target;
-  char* err_msg;
+  char *target;
+  char *err_msg;
   mrb_value f = mrb_nil_value();
   int umountflag, ret;
 
@@ -64,11 +65,12 @@ static mrb_value mrb_mount_umount(mrb_state *mrb, mrb_value self)
   ret = umount2(target, umountflag);
   if(ret == -1) {
     char buf[1024];
-    if (strerror_r(errno, buf, 1024) == NULL) {
+    char *ret;
+    if ((ret = strerror_r(errno, buf, 1024)) == NULL) {
       mrb_sys_fail(mrb, "[BUG] strerror_r failed at mrb_mount.c:68. Please report haconiwa-dev");
     }
 
-    asprintf(&err_msg, "umount failed: %s", buf);
+    asprintf(&err_msg, "umount failed: %s", ret);
     mrb_sys_fail(mrb, err_msg);
   }
 

--- a/src/mrb_mount.c
+++ b/src/mrb_mount.c
@@ -10,6 +10,8 @@
 
 #include <stdio.h>
 #include <sys/mount.h>
+#include <errno.h>
+#include <string.h>
 
 #include <mruby.h>
 #include <mruby/data.h>
@@ -18,24 +20,8 @@
 
 #define DONE mrb_gc_arena_restore(mrb, 0);
 
-typedef struct {
-  char *str;
-  int len;
-} mrb_mount_data;
-
-static const struct mrb_data_type mrb_mount_data_type = {
-  "mrb_mount_data", mrb_free,
-};
-
 static mrb_value mrb_mount_init(mrb_state *mrb, mrb_value self)
 {
-  mrb_mount_data *data;
-
-  data = (mrb_mount_data *)DATA_PTR(self);
-  if (data) {
-    mrb_free(mrb, data);
-  }
-  DATA_TYPE(self) = &mrb_mount_data_type;
   DATA_PTR(self) = NULL;
 
   return self;
@@ -55,7 +41,7 @@ static mrb_value mrb_mount_mount(mrb_state *mrb, mrb_value self)
   if(ret == -1) {
     char buf[1024];
     if (strerror_r(errno, buf, 1024) == NULL) {
-      mrb_sys_fail(mrb, "[BUG] strerror_r failed at mrb_mount.c:" __LINE__ ". Please report haconiwa-dev");
+      mrb_sys_fail(mrb, "[BUG] strerror_r failed at mrb_mount.c:44. Please report haconiwa-dev");
     }
 
     asprintf(&err_msg, "syscall mount failed. message: %s, args: %s, %s, %s, %i, %s", buf, source, target, fstype, mountflag, data);
@@ -79,7 +65,7 @@ static mrb_value mrb_mount_umount(mrb_state *mrb, mrb_value self)
   if(ret == -1) {
     char buf[1024];
     if (strerror_r(errno, buf, 1024) == NULL) {
-      mrb_sys_fail(mrb, "[BUG] strerror_r failed at mrb_mount.c:" __LINE__ ". Please report haconiwa-dev");
+      mrb_sys_fail(mrb, "[BUG] strerror_r failed at mrb_mount.c:68. Please report haconiwa-dev");
     }
 
     asprintf(&err_msg, "umount failed: %s", buf);

--- a/test/mrb_mount.rb
+++ b/test/mrb_mount.rb
@@ -3,15 +3,6 @@
 ##
 
 assert("Mount#hello") do
-  t = Mount.new "hello"
-  assert_equal("hello", t.hello)
-end
-
-assert("Mount#bye") do
-  t = Mount.new "hello"
-  assert_equal("hello bye", t.bye)
-end
-
-assert("Mount.hi") do
-  assert_equal("hi!!", Mount.hi)
+  t = Mount.new
+  assert_equal(Mount, t.class)
 end


### PR DESCRIPTION
## Before:

```
> m.bind_mount "/proc", "/foo"
mount: No such file or directory #<= from `perror' !!!
(mirb):3: syscall mount failed. args: /proc, /foo, , -1058205696, (null) (RuntimeError)
```

## After:

```
> m.bind_mount "/proc", "/foo"
(mirb):2: syscall mount failed. message: No such file or directory, args: /proc, /foo (RuntimeError)
```