### PR TITLE
Support clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+# requires clang-format >= 3.6
+BasedOnStyle: "LLVM"
+IndentWidth: 2
+ColumnLimit: 120
+BreakBeforeBraces: Linux
+AllowShortFunctionsOnASingleLine: None

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ m.mount("proc", "/proc", type: "proc")
 
 This mgem may work only Linux.
 
+## Formatter
+
+```
+clang-format -i src/mrb_mount.c
+clang-format -i src/mrb_mount.h
+```
+
 ## License
 
 under the MIT License:

--- a/src/mrb_mount.c
+++ b/src/mrb_mount.c
@@ -8,15 +8,15 @@
 
 #define _GNU_SOURCE
 
-#include <stdio.h>
-#include <sys/mount.h>
 #include <errno.h>
+#include <stdio.h>
 #include <string.h>
+#include <sys/mount.h>
 
+#include "mrb_mount.h"
 #include <mruby.h>
 #include <mruby/data.h>
 #include <mruby/error.h>
-#include "mrb_mount.h"
 
 #define DONE mrb_gc_arena_restore(mrb, 0);
 
@@ -30,15 +30,15 @@ static mrb_value mrb_mount_init(mrb_state *mrb, mrb_value self)
 static mrb_value mrb_mount_mount(mrb_state *mrb, mrb_value self)
 {
   // mrb_mount_data *d = DATA_PTR(self);
-  char* source, * target, * fstype, * data;
+  char *source, *target, *fstype, *data;
   mrb_int mountflag;
   int ret;
-  char* err_msg;
+  char *err_msg;
 
   mrb_get_args(mrb, "zzz!iz!", &source, &target, &fstype, &mountflag, &data);
 
   ret = mount(source, target, fstype, mountflag, data);
-  if(ret == -1) {
+  if (ret == -1) {
     char buf[1024];
     char *ret;
     if ((ret = strerror_r(errno, buf, 1024)) == NULL) {
@@ -64,7 +64,7 @@ static mrb_value mrb_mount_umount(mrb_state *mrb, mrb_value self)
   umountflag = mrb_nil_p(f) ? 0 : mrb_fixnum(f);
 
   ret = umount2(target, umountflag);
-  if(ret == -1) {
+  if (ret == -1) {
     char buf[1024];
     char *ret;
     if ((ret = strerror_r(errno, buf, 1024)) == NULL) {
@@ -84,29 +84,29 @@ void mrb_mruby_mount_gem_init(mrb_state *mrb)
   struct RClass *mount;
   mount = mrb_define_class(mrb, "Mount", mrb->object_class);
   mrb_define_method(mrb, mount, "initialize", mrb_mount_init, MRB_ARGS_NONE());
-  mrb_define_method(mrb, mount, "__mount__",  mrb_mount_mount, MRB_ARGS_REQ(5));
-  mrb_define_method(mrb, mount, "umount",     mrb_mount_umount, MRB_ARGS_ARG(1, 1));
+  mrb_define_method(mrb, mount, "__mount__", mrb_mount_mount, MRB_ARGS_REQ(5));
+  mrb_define_method(mrb, mount, "umount", mrb_mount_umount, MRB_ARGS_ARG(1, 1));
 
   // please see <linux/fs.h>
-  mrb_define_const(mrb, mount, "MS_MGC_VAL",     mrb_fixnum_value(MS_MGC_VAL));
+  mrb_define_const(mrb, mount, "MS_MGC_VAL", mrb_fixnum_value(MS_MGC_VAL));
 
-  mrb_define_const(mrb, mount, "MS_DIRSYNC",     mrb_fixnum_value(MS_DIRSYNC));
-  mrb_define_const(mrb, mount, "MS_MANDLOCK",    mrb_fixnum_value(MS_MANDLOCK));
-  mrb_define_const(mrb, mount, "MS_MOVE",        mrb_fixnum_value(MS_MOVE));
-  mrb_define_const(mrb, mount, "MS_NOATIME",     mrb_fixnum_value(MS_NOATIME));
-  mrb_define_const(mrb, mount, "MS_NODEV",       mrb_fixnum_value(MS_NODEV));
-  mrb_define_const(mrb, mount, "MS_NODIRATIME",  mrb_fixnum_value(MS_NODIRATIME));
-  mrb_define_const(mrb, mount, "MS_NOEXEC",      mrb_fixnum_value(MS_NOEXEC));
-  mrb_define_const(mrb, mount, "MS_NOSUID",      mrb_fixnum_value(MS_NOSUID));
-  mrb_define_const(mrb, mount, "MS_RDONLY",      mrb_fixnum_value(MS_RDONLY));
-  mrb_define_const(mrb, mount, "MS_REMOUNT",     mrb_fixnum_value(MS_REMOUNT));
+  mrb_define_const(mrb, mount, "MS_DIRSYNC", mrb_fixnum_value(MS_DIRSYNC));
+  mrb_define_const(mrb, mount, "MS_MANDLOCK", mrb_fixnum_value(MS_MANDLOCK));
+  mrb_define_const(mrb, mount, "MS_MOVE", mrb_fixnum_value(MS_MOVE));
+  mrb_define_const(mrb, mount, "MS_NOATIME", mrb_fixnum_value(MS_NOATIME));
+  mrb_define_const(mrb, mount, "MS_NODEV", mrb_fixnum_value(MS_NODEV));
+  mrb_define_const(mrb, mount, "MS_NODIRATIME", mrb_fixnum_value(MS_NODIRATIME));
+  mrb_define_const(mrb, mount, "MS_NOEXEC", mrb_fixnum_value(MS_NOEXEC));
+  mrb_define_const(mrb, mount, "MS_NOSUID", mrb_fixnum_value(MS_NOSUID));
+  mrb_define_const(mrb, mount, "MS_RDONLY", mrb_fixnum_value(MS_RDONLY));
+  mrb_define_const(mrb, mount, "MS_REMOUNT", mrb_fixnum_value(MS_REMOUNT));
   mrb_define_const(mrb, mount, "MS_SYNCHRONOUS", mrb_fixnum_value(MS_SYNCHRONOUS));
-  mrb_define_const(mrb, mount, "MS_BIND",        mrb_fixnum_value(MS_BIND));
-  mrb_define_const(mrb, mount, "MS_PRIVATE",     mrb_fixnum_value(MS_PRIVATE));
-  mrb_define_const(mrb, mount, "MS_REC",         mrb_fixnum_value(MS_REC));
-  mrb_define_const(mrb, mount, "MS_SLAVE",       mrb_fixnum_value(MS_SLAVE));
+  mrb_define_const(mrb, mount, "MS_BIND", mrb_fixnum_value(MS_BIND));
+  mrb_define_const(mrb, mount, "MS_PRIVATE", mrb_fixnum_value(MS_PRIVATE));
+  mrb_define_const(mrb, mount, "MS_REC", mrb_fixnum_value(MS_REC));
+  mrb_define_const(mrb, mount, "MS_SLAVE", mrb_fixnum_value(MS_SLAVE));
 
-  mrb_define_const(mrb, mount, "MNT_FORCE",  mrb_fixnum_value(MNT_FORCE));
+  mrb_define_const(mrb, mount, "MNT_FORCE", mrb_fixnum_value(MNT_FORCE));
   mrb_define_const(mrb, mount, "MNT_DETACH", mrb_fixnum_value(MNT_DETACH));
   mrb_define_const(mrb, mount, "MNT_EXPIRE", mrb_fixnum_value(MNT_EXPIRE));
 

--- a/src/mrb_mount.c
+++ b/src/mrb_mount.c
@@ -8,15 +8,17 @@
 
 #define _GNU_SOURCE
 
-#include <errno.h>
+// clang-format off
 #include <stdio.h>
-#include <string.h>
 #include <sys/mount.h>
+#include <errno.h>
+#include <string.h>
 
-#include "mrb_mount.h"
 #include <mruby.h>
 #include <mruby/data.h>
 #include <mruby/error.h>
+#include "mrb_mount.h"
+// clang-format on
 
 #define DONE mrb_gc_arena_restore(mrb, 0);
 


### PR DESCRIPTION
@udzura  clang-format is very useful code formatter. We should use code format for PR. What do you think?